### PR TITLE
Fixed LazyTable not adjusting correctly while shrinking width

### DIFF
--- a/table/src/commonMain/kotlin/majestic/Table.kt
+++ b/table/src/commonMain/kotlin/majestic/Table.kt
@@ -59,12 +59,12 @@ fun <D> LazyTable(
 
     LazyColumn(modifier.onPlaced { width = with(density) { (it.parentCoordinates?.size?.width ?: 300).toDp() } }) {
         if (columns.renderer != null) stickyHeader {
-            Row(modifier = columns.modifier.width(width)) {
+            Row {
                 for (column in columns.data) columns.renderer.invoke(this, column)
             }
         }
         items(rows) { row ->
-            Row(modifier = Modifier.width(width)) {
+            Row{
                 for (column in columns.data) cell(this, Cell(column, row))
             }
         }


### PR DESCRIPTION
Fixed LazyTable not adjusting correctly while shrinking width but requesting guidance/confirmation on moving forward with api change. Since, now LazyTable doesnt automatically set widths of columns anymore, all LazyTable calls, require explicit width specification of columns, which fixes the Admissions table, but kinda breaks other simple LazyTable calls, like in Blog